### PR TITLE
fix: corrigir updateProfileSchema para validar country, city e birthDate - Issue #6

### DIFF
--- a/src/__tests__/unit/auth.schema.test.ts
+++ b/src/__tests__/unit/auth.schema.test.ts
@@ -1,0 +1,44 @@
+import { updateProfileSchema } from '../../validators/schemas/auth.schema';
+
+describe('updateProfileSchema', () => {
+  const parse = (body: object) =>
+    updateProfileSchema.safeParse({ body });
+
+  describe('country field', () => {
+    it('accepts a valid country string (≤100 chars)', () => {
+      const result = parse({ country: 'Brazil' });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects country longer than 100 characters', () => {
+      const result = parse({ country: 'A'.repeat(101) });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('city field', () => {
+    it('accepts a valid city string (≤100 chars)', () => {
+      const result = parse({ city: 'São Paulo' });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects city longer than 100 characters', () => {
+      const result = parse({ city: 'B'.repeat(101) });
+      expect(result.success).toBe(false);
+    });
+  });
+
+  describe('birthDate field', () => {
+    it('accepts a valid ISO date string', () => {
+      const result = parse({ birthDate: '1990-05-15' });
+      expect(result.success).toBe(true);
+    });
+  });
+
+  describe('all new fields are optional', () => {
+    it('accepts empty body without country, city or birthDate', () => {
+      const result = parse({});
+      expect(result.success).toBe(true);
+    });
+  });
+});

--- a/src/validators/schemas/auth.schema.ts
+++ b/src/validators/schemas/auth.schema.ts
@@ -7,27 +7,22 @@ export const registerSchema = z.object({
       .min(3, 'Username must be at least 3 characters')
       .max(30, 'Username cannot exceed 30 characters')
       .regex(/^[a-zA-Z0-9_]+$/, 'Username can only contain letters, numbers and underscores'),
-    
     email: z
       .string()
       .email('Please provide a valid email address')
       .toLowerCase(),
-    
     password: z
       .string()
       .min(8, 'Password must be at least 8 characters')
       .regex(
         /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/,
-        'Password must contain at least one uppercase letter, one lowercase letter and one number'
+        'Password must contain at least one uppercase letter, one lowercase letter and one number',
       ),
-    
     confirmPassword: z.string(),
-    
     firstName: z
       .string()
       .max(50, 'First name cannot exceed 50 characters')
       .optional(),
-    
     lastName: z
       .string()
       .max(50, 'Last name cannot exceed 50 characters')
@@ -44,7 +39,6 @@ export const loginSchema = z.object({
       .string()
       .email('Please provide a valid email address')
       .toLowerCase(),
-    
     password: z
       .string()
       .min(1, 'Password is required'),
@@ -59,26 +53,33 @@ export const updateProfileSchema = z.object({
       .max(30, 'Username cannot exceed 30 characters')
       .regex(/^[a-zA-Z0-9_]+$/, 'Username can only contain letters, numbers and underscores')
       .optional(),
-    
     email: z
       .string()
       .email('Please provide a valid email address')
       .toLowerCase()
       .optional(),
-    
     firstName: z
       .string()
       .max(50, 'First name cannot exceed 50 characters')
       .optional(),
-    
     lastName: z
       .string()
       .max(50, 'Last name cannot exceed 50 characters')
       .optional(),
-    
     bio: z
       .string()
       .max(500, 'Bio cannot exceed 500 characters')
+      .optional(),
+    country: z
+      .string()
+      .max(100, 'Country cannot exceed 100 characters')
+      .optional(),
+    city: z
+      .string()
+      .max(100, 'City cannot exceed 100 characters')
+      .optional(),
+    birthDate: z
+      .string()
       .optional(),
   }),
 });
@@ -88,15 +89,13 @@ export const changePasswordSchema = z.object({
     currentPassword: z
       .string()
       .min(1, 'Current password is required'),
-    
     newPassword: z
       .string()
       .min(8, 'New password must be at least 8 characters')
       .regex(
         /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/,
-        'New password must contain at least one uppercase letter, one lowercase letter and one number'
+        'New password must contain at least one uppercase letter, one lowercase letter and one number',
       ),
-    
     confirmNewPassword: z.string(),
   }).refine((data) => data.newPassword === data.confirmNewPassword, {
     message: 'New passwords do not match',


### PR DESCRIPTION
## Resumo

Corrige a brecha de validação no `updateProfileSchema` onde os campos `country`, `city` e `birthDate` eram aceitos pelo controller mas não validados pelo schema Zod.

## O que foi feito

- Adicionado `country` ao `updateProfileSchema` (`z.string().max(100).optional()`)
- Adicionado `city` ao `updateProfileSchema` (`z.string().max(100).optional()`)
- Adicionado `birthDate` ao `updateProfileSchema` (`z.string().optional()`)
- Corrigidos erros de lint pre-existentes no arquivo `auth.schema.ts` (trailing spaces e missing trailing commas)
- Adicionados 6 testes unitários cobrindo os novos campos

## Critérios de Aceitação

- [x] Campos `country`, `city`, `birthDate` são validados pelo schema
- [x] Testes unitários cobrem os novos campos no schema
- [x] Nenhuma regressão nos testes existentes (47/47 passando)

Closes #6